### PR TITLE
fixed bug in decode_beam_search

### DIFF
--- a/src/decoding.py
+++ b/src/decoding.py
@@ -341,7 +341,7 @@ def decode_beam_search(transducer,
                                 trg_bos=BOS_IDX,
                                 trg_eos=EOS_IDX)
 
-    if isinstance(transducer, HardMonoTransducer):
+    if isinstance(transducer, HMMTransducer):
         return decode_beam_hmm(transducer,
                                src_sentence,
                                max_len=max_len,


### PR DESCRIPTION
Hi

There seems to be a bug in `src/decoding.py` line 344. I think it should be `if isinstance(transducer, HMMTransducer)` instead of `if isinstance(transducer, HardMonoTransducer)`. 