### PR TITLE
Update bash script arguments (sigmorphon 2021)

### DIFF
--- a/example/sigmorphon2021-shared-tasks/task0-trm-hall.sh
+++ b/example/sigmorphon2021-shared-tasks/task0-trm-hall.sh
@@ -16,7 +16,7 @@ layers=4
 hs=1024
 embed_dim=256
 nb_heads=4
-dropout=${2:-0.3}
+dropout=${3:-0.3}
 
 ckpt_dir=checkpoints/sig21
 

--- a/example/sigmorphon2021-shared-tasks/task0-trm.sh
+++ b/example/sigmorphon2021-shared-tasks/task0-trm.sh
@@ -16,7 +16,7 @@ layers=4
 hs=1024
 embed_dim=256
 nb_heads=4
-dropout=${2:-0.3}
+dropout=${3:-0.3}
 
 ckpt_dir=checkpoints/sig21
 


### PR DESCRIPTION
Another small fix: both `arch` and `dropout` variables were taking their value from the second positional argument to the bash script, which I'm assuming was not intentional.